### PR TITLE
clear timer with "ta clr"

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -299,3 +299,19 @@ function timerHistory() {
     }
   }
 }
+
+function clearAllNotifications() {
+  //Rewrite the timer
+  chrome.storage.local.get({timers: []}, function(object) {
+    timers = object.timers;
+    //Locate the index
+    for(var i =0; i< timers.length; i++) {
+      timers[i].status="cancelled";
+      root.clearTimeout(parseInt(timers[i].tid));
+    }
+    root.timercount = 0
+      //chrome.storage.local.set({timers: timers});
+      chrome.storage.local.set({timers: []});
+  });
+}
+

--- a/src/background.js
+++ b/src/background.js
@@ -300,6 +300,8 @@ function timerHistory() {
   }
 }
 
+var root = chrome.extension.getBackgroundPage();
+
 function clearAllNotifications() {
   //Rewrite the timer
   chrome.storage.local.get({timers: []}, function(object) {

--- a/src/chrome.js
+++ b/src/chrome.js
@@ -20,31 +20,8 @@ function updateDefaultSuggestion(text) {
   if (text.trim() === "") {
     resetDefaultSuggestion();
   } else {
-
-    var arr = text.split(/\s+/);
-    var seconds = parseTime(arr.shift());
-    if (!seconds) {
-      console.log("parse error: " + text);
-      giveFeedback("err");
-    }
-
-    if (arr.length > 0) {
-      desc = arr.join(" ");
-    } else {
-      desc = 'Timer done!';
-    }
-
-    var timer = {
-      currentTime: (new Date()).getTime(),
-      desc: desc,
-      seconds: seconds,
-      popup: 0
-    };
-
-    var notificationTime = timer.currentTime + timer.seconds * 1000;
-
     chrome.omnibox.setDefaultSuggestion({
-      description: 'Timer set: <match>' + text + '</match> | &lt;time&gt; [&lt;message&gt;] | ' + 'Will alert in ' + moment(notificationTime).calendar()
+      description: 'Timer set: <match>' + text + '</match> | &lt;time&gt; [&lt;message&gt;]'
     });
   }
 }

--- a/src/chrome.js
+++ b/src/chrome.js
@@ -6,6 +6,8 @@ chrome.omnibox.onInputEntered.addListener(function(text){
   console.log(thistory);
   if (text == "options" || text == "show") {
     openOptionsPage();
+  } else if (text == "clr"){
+    clearAllNotifications();
   } else {
     var result = tryToSetupTimer(text);
 

--- a/src/chrome.js
+++ b/src/chrome.js
@@ -20,8 +20,31 @@ function updateDefaultSuggestion(text) {
   if (text.trim() === "") {
     resetDefaultSuggestion();
   } else {
+
+    var arr = text.split(/\s+/);
+    var seconds = parseTime(arr.shift());
+    if (!seconds) {
+      console.log("parse error: " + text);
+      giveFeedback("err");
+    }
+
+    if (arr.length > 0) {
+      desc = arr.join(" ");
+    } else {
+      desc = 'Timer done!';
+    }
+
+    var timer = {
+      currentTime: (new Date()).getTime(),
+      desc: desc,
+      seconds: seconds,
+      popup: 0
+    };
+
+    var notificationTime = timer.currentTime + timer.seconds * 1000;
+
     chrome.omnibox.setDefaultSuggestion({
-      description: 'Timer set: <match>' + text + '</match> | &lt;time&gt; [&lt;message&gt;]'
+      description: 'Timer set: <match>' + text + '</match> | &lt;time&gt; [&lt;message&gt;] | ' + 'Will alert in ' + moment(notificationTime).calendar()
     });
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,6 @@
 
   "background": {
     "scripts": [
-      "moment.js",
       "background.js",
       "chrome.js"
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,7 @@
 
   "background": {
     "scripts": [
+      "moment.js",
       "background.js",
       "chrome.js"
     ]


### PR DESCRIPTION
add the shortcut ta clr

The ta clr, simply clears all the timers and notifications. I've copied paste your code, so there might be some modifications to do...

Anyways, I did that so I can explain to the 40 users on my plugin that's its time to move. So that the 40 users on my shop can feel at home with the new plugin. 

![clearfuturetimers](https://user-images.githubusercontent.com/7820699/33176249-6af21c64-d02c-11e7-93e2-a72130f0f325.png)
